### PR TITLE
chore: update dependencies and ignore Aider files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+.aider*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 actix-session = { version = "0.10.1", features = ["redis-session-native-tls"] }
 actix-web = "4.5.1"
 actix-web-flash-messages = { version = "0.5.0", features = ["cookies"] }
-actix-web-lab = "0.23.0"
 anyhow = "1.0.82"
 argon2 = { version = "0.5.3", features = ["std"] }
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }


### PR DESCRIPTION
Remove actix-web-lab dependency from Cargo.toml to streamline 
the project and avoid potential conflicts. Add .aider* to 
.gitignore to prevent Aider-related files from being tracked.